### PR TITLE
Fix json serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
     - "2.7"
 
 install:
-    - pip install -e . -r ./requirements.txt  
+    - pip install -e . -r ./requirements/dev 
 
 script:
     - nosetests tests/

--- a/arteria/web/handlers.py
+++ b/arteria/web/handlers.py
@@ -11,8 +11,20 @@ class BaseRestHandler(tornado.web.RequestHandler):
         pass
 
     def write_object(self, obj):
-        resp = jsonpickle.encode(obj, unpicklable=False)
-        self.write_json(resp)
+        """
+        Writes the object as JSON
+
+        Only dictionaries or objects containing the __dict__ attribute get serialized.
+        """
+        if isinstance(obj, dict):
+            resp = obj
+        elif hasattr(obj, "__dict__"):
+            resp = obj.__dict__
+        else:
+            raise TypeError("The object needs either to be a dict or have the __dict__ attribute")
+
+        # Send to Tornado, which handles the json serialization and content-type header
+        self.write(resp)
 
     def write_json(self, json):
         self.set_header("Content-Type", "application/json")
@@ -64,3 +76,5 @@ class ApiHelpHandler(BaseRestHandler):
         base_url = "{0}://{1}".format(self.request.protocol, self.request.host)
         help_doc = self.route_svc.get_help(base_url)
         self.write_object(help_doc)
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requirements/prod
+./requirements/dev

--- a/tests/unit/web_handlers_tests.py
+++ b/tests/unit/web_handlers_tests.py
@@ -1,0 +1,41 @@
+from arteria.web.handlers import BaseRestHandler
+import unittest
+import mock
+
+
+class TestHandlers(unittest.TestCase):
+    def test_cant_deserialize_list(self):
+        """
+        It shouldn't be possible to deserialize to json lists:
+        http://haacked.com/archive/2009/06/25/json-hijacking.aspx/
+        """
+        handler = BaseRestHandler(mock.MagicMock(), mock.MagicMock())
+        obj = "This would be bad".split(' ')
+        self.assertRaises(TypeError, handler.write_object, obj)
+
+    def test_can_deserialize_plain_object(self):
+        """Sending an non-list/non-dict object to write_object deserializes it as json"""
+        handler = BaseRestHandler(mock.MagicMock(), mock.MagicMock())
+        handler._write_buffer = []
+        obj = SerializeMe()
+        obj.key = "value"
+        handler.write_object(obj)
+        json = handler._write_buffer[0]
+        self.assertTrue(json == '{"key": "value"}')
+
+    def test_can_deserialize_dict(self):
+        handler = BaseRestHandler(mock.MagicMock(), mock.MagicMock())
+        handler._write_buffer = []
+        obj = {"key": "value"}
+        handler.write_object(obj)
+        json = handler._write_buffer[0]
+        self.assertTrue(json == '{"key": "value"}')
+
+    def test_cant_deserialize_tuple(self):
+        handler = BaseRestHandler(mock.MagicMock(), mock.MagicMock())
+        obj = ("this", "that")
+        self.assertRaises(TypeError, handler.write_object, obj)
+
+
+class SerializeMe:
+    pass


### PR DESCRIPTION
Ensuring that lists can't be deserialized to json (potential security risk):
* Only objects having __dict__ or dictionaries can be serialized with write_object
* Tests
* Additional: requirements.txt pointing to requirements/dev instead of prod