### PR TITLE
API documentation wasn't showing up

### DIFF
--- a/arteria/web/routes.py
+++ b/arteria/web/routes.py
@@ -120,7 +120,7 @@ class RouteService:
                 if not self._help_generated:
                     self._route_infos = self._get_route_infos_grouped(self._routes, base_url)
                     self._help_generated = True
-        return self._route_infos
+        return {"doc": self._route_infos}
 
 class RoutesNotSetError(Exception):
     pass


### PR DESCRIPTION
The API was showing as a list of runfolderinfos. A list can't be returned anymore.
Returning a dictionary with one key, 'doc' instead.