### PR TITLE
Add ready to known states

### DIFF
--- a/arteria/web/state.py
+++ b/arteria/web/state.py
@@ -6,6 +6,7 @@ when running jobs and querying for their status.
 class State:
     NONE = "none"
     PENDING = "pending"
+    READY = "ready"
     STARTED = "started"
     DONE = "done"
     ERROR = "error"


### PR DESCRIPTION
`READY` is a state used by the runfolder service. To harmonize possible states across services I've added it here.