### PR TITLE
Remove json pickle as dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.tox
 *.swp
 *.pyc
 .idea/

--- a/arteria/testhelpers.py
+++ b/arteria/testhelpers.py
@@ -1,8 +1,10 @@
 import time
-import jsonpickle
 import requests
 import re
+import json
+
 import unittest
+
 
 class BaseRestTest(unittest.TestCase):
     def _base_url(self):
@@ -24,9 +26,9 @@ class BaseRestTest(unittest.TestCase):
         :param obj: A Python object
         :param expect: The expected status code
         """
-        json = jsonpickle.encode(obj)
+        json_body = json.dumps(obj)
         full_url = self._get_full_url(url)
-        resp = requests.put(full_url, json)
+        resp = requests.put(full_url, json_body)
         self._validate_response(resp, expect)
         return resp
 

--- a/arteria/web/handlers.py
+++ b/arteria/web/handlers.py
@@ -1,6 +1,5 @@
 import tornado.web
-import jsonpickle
-
+import json
 
 class BaseRestHandler(tornado.web.RequestHandler):
     """
@@ -33,7 +32,7 @@ class BaseRestHandler(tornado.web.RequestHandler):
 
     def body_as_object(self, required_members=[]):
         """Returns the JSON encoded body as a Python object"""
-        obj = jsonpickle.decode(self.request.body)
+        obj = json.loads(self.request.body)
         for member in required_members:
             if member not in obj:
                 raise tornado.web.HTTPError("400", "Expecting '{0}' in the JSON body".format(member))

--- a/requirements/prod
+++ b/requirements/prod
@@ -1,4 +1,3 @@
-jsonpickle==0.9.2
 tornado==4.2.1
 PyYAML==3.13
 requests==2.20.0

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages
 from arteria import __version__
 import os
 
+
 def read_file(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 


### PR DESCRIPTION
**What problems does this PR solve?**
This removes our dependency on json pickle and makes sure  json loading that we do is safe using `loads` rather than `load`.

**How has the changes been tested?**
Only automatic tests have been run.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be initiated.

  - [ ] This PR contains code that could remove data
