### PR TITLE
DEVELOP-2192: make it possible to ignore extra args from `sys.argv` when testing

### DIFF
--- a/arteria/web/app.py
+++ b/arteria/web/app.py
@@ -57,7 +57,7 @@ class AppService:
         self._tornado = None
 
     @classmethod
-    def create(cls, product_name=None, config_root=None):
+    def create(cls, product_name=None, config_root=None, args=None):
         """
         Creates the default app service based on arguments sent from the
         command line and related services with defaults based on the
@@ -97,7 +97,7 @@ class AppService:
         parser.add_argument(
                 "--debug",
                 dest="debug", action="store_true", default=False)
-        args = parser.parse_args()
+        args = parser.parse_args(args=args)
 
         if args.product:
             product_name = args.product

--- a/arteria/web/app.py
+++ b/arteria/web/app.py
@@ -59,8 +59,9 @@ class AppService:
     @classmethod
     def create(cls, product_name=None, config_root=None):
         """
-        Creates the default app service based on arguments sent from the command line
-        and related services with defaults based on the product_name.
+        Creates the default app service based on arguments sent from the
+        command line and related services with defaults based on the
+        product_name.
 
         If the product_name is specified via the command line, it will override
         the argument.
@@ -75,18 +76,27 @@ class AppService:
             - /etc/arteria/<product_name>/app.config
             - /etc/arteria/<product_name>/logger.config
 
-        You can override this by supplying config_root, in which case they should be
-        found at <config_root>/*.config
+        You can override this by supplying config_root, in which case they
+        should be found at <config_root>/*.config
 
-        :param product_name: Should by convention be __package__. This value can be overriden
-                             by supplying the --product parameter on the command line.
+        :param product_name: Should by convention be __package__. This value
+        can be overriden by supplying the --product parameter on the command
+        line.
         """
 
         parser = ArgumentParser()
-        parser.add_argument("--product", dest="product", metavar="PRODUCT")
-        parser.add_argument("--port", dest="port", metavar="PORT")
-        parser.add_argument("--debug", dest="debug", action="store_true", default=False)
-        parser.add_argument("--configroot", dest="configroot", metavar="CONFIGROOT")
+        parser.add_argument(
+                "--product",
+                dest="product", metavar="PRODUCT")
+        parser.add_argument(
+                "--port",
+                dest="port", metavar="PORT")
+        parser.add_argument(
+                "--configroot",
+                dest="configroot", metavar="CONFIGROOT")
+        parser.add_argument(
+                "--debug",
+                dest="debug", action="store_true", default=False)
         args = parser.parse_args()
 
         if args.product:
@@ -94,25 +104,31 @@ class AppService:
 
         if not product_name:
             raise ProductNameError(
-                "No product name was supplied via the command line or as an argument to create")
+                "No product name was supplied via the command line"
+                " or as an argument to create")
 
         if not config_root:
-            config_root = args.configroot or os.path.join("/etc", "arteria", product_name)
+            config_root = (
+                    args.configroot
+                    or os.path.join("/etc", "arteria", product_name)
+                    )
 
         logger_config_path = os.path.join(config_root, "logger.config")
         app_config_path = os.path.join(config_root, "app.config")
-        config_svc = ConfigurationService(logger_config_path=logger_config_path,
-                                          app_config_path=app_config_path)
+        config_svc = ConfigurationService(
+                logger_config_path=logger_config_path,
+                app_config_path=app_config_path)
 
         # Port from commandline should override,
-        # otherwise pick the port specified in the
-        # config.
+        # otherwise pick the port specified in the config.
         if args.port:
             port = args.port
         elif config_svc["port"]:
             port = config_svc["port"]
         else:
-            parser.error("You have to specify a port, either via the commandline, or in the config (key: 'port').")
+            parser.error(
+                    "You have to specify a port, either via the commandline,"
+                    " or in the config (key: 'port').")
 
         return cls(config_svc, args.debug, port)
 

--- a/arteria/web/app.py
+++ b/arteria/web/app.py
@@ -5,7 +5,7 @@ import os
 from arteria.configuration import ConfigurationService
 from arteria.web.routes import RouteService
 from arteria.web.handlers import LogLevelHandler, ApiHelpHandler
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 
 class AppService:
@@ -82,22 +82,22 @@ class AppService:
                              by supplying the --product parameter on the command line.
         """
 
-        parser = OptionParser()
-        parser.add_option("--product", dest="product", metavar="PRODUCT")
-        parser.add_option("--port", dest="port", metavar="PORT")
-        parser.add_option("--debug", dest="debug", action="store_true", default=False)
-        parser.add_option("--configroot", dest="configroot", metavar="CONFIGROOT")
-        (options, args) = parser.parse_args()
+        parser = ArgumentParser()
+        parser.add_argument("--product", dest="product", metavar="PRODUCT")
+        parser.add_argument("--port", dest="port", metavar="PORT")
+        parser.add_argument("--debug", dest="debug", action="store_true", default=False)
+        parser.add_argument("--configroot", dest="configroot", metavar="CONFIGROOT")
+        args = parser.parse_args()
 
-        if options.product:
-            product_name = options.product
+        if args.product:
+            product_name = args.product
 
         if not product_name:
             raise ProductNameError(
                 "No product name was supplied via the command line or as an argument to create")
 
         if not config_root:
-            config_root = options.configroot or os.path.join("/etc", "arteria", product_name)
+            config_root = args.configroot or os.path.join("/etc", "arteria", product_name)
 
         logger_config_path = os.path.join(config_root, "logger.config")
         app_config_path = os.path.join(config_root, "app.config")
@@ -107,14 +107,14 @@ class AppService:
         # Port from commandline should override,
         # otherwise pick the port specified in the
         # config.
-        if options.port:
-            port = options.port
+        if args.port:
+            port = args.port
         elif config_svc["port"]:
             port = config_svc["port"]
         else:
             parser.error("You have to specify a port, either via the commandline, or in the config (key: 'port').")
 
-        app_svc = AppService(config_svc, options.debug, port)
+        app_svc = AppService(config_svc, args.debug, port)
         return app_svc
 
     def start(self, routes):

--- a/arteria/web/app.py
+++ b/arteria/web/app.py
@@ -56,8 +56,8 @@ class AppService:
         self._logger.info("Logger initialized by AppService")
         self._tornado = None
 
-    @staticmethod
-    def create(product_name=None, config_root=None):
+    @classmethod
+    def create(cls, product_name=None, config_root=None):
         """
         Creates the default app service based on arguments sent from the command line
         and related services with defaults based on the product_name.
@@ -114,8 +114,7 @@ class AppService:
         else:
             parser.error("You have to specify a port, either via the commandline, or in the config (key: 'port').")
 
-        app_svc = AppService(config_svc, args.debug, port)
-        return app_svc
+        return cls(config_svc, args.debug, port)
 
     def start(self, routes):
         # Add the default routes, such as the API handler

--- a/tests/appservice_integrations_tests.py
+++ b/tests/appservice_integrations_tests.py
@@ -3,14 +3,18 @@ import os
 from arteria.web.app import AppService
 from unittest import TestCase
 
+
 class AppServiceTest(TestCase):
 
     this_file_path = os.path.dirname(os.path.realpath(__file__))
 
     def test_can_load_configuration(self):
-        app_svc = AppService.create("arteria-test", "{}/../templates/".format(self.this_file_path))
+        app_svc = AppService.create(
+                product_name="arteria-test",
+                config_root="{}/../templates/".format(self.this_file_path))
         self.assertIsNotNone(app_svc.config_svc)
         app_config = app_svc.config_svc.get_app_config()
         logger_config = app_svc.config_svc.get_logger_config()
-        self.assertTrue(app_config["port"] == 10000)
-        self.assertTrue(logger_config["version"] == 1)
+
+        self.assertEquals(app_config["port"], 10000)
+        self.assertEquals(logger_config["version"], 1)

--- a/tests/appservice_integrations_tests.py
+++ b/tests/appservice_integrations_tests.py
@@ -18,3 +18,11 @@ class AppServiceTest(TestCase):
 
         self.assertEquals(app_config["port"], 10000)
         self.assertEquals(logger_config["version"], 1)
+
+    def test_can_use_args(self):
+        app_svc = AppService.create(
+                product_name="arteria-test",
+                config_root="{}/../templates/".format(self.this_file_path),
+                args=['--port', '1234'])
+
+        self.assertEquals(app_svc._port, 1234)


### PR DESCRIPTION
**What problems does this PR solve?**
During instantiation, `AppService` will process all the arguments from `sys.argv`. This is a problem because it will also try to process the arguments meant for `nosetests`/`pytest` during integration testing.

This PR makes it possible to specifically provide the arguments to be processed (instead of the default `sys.argv`). The integration tests for our web services can then be updated to ignore `sys.argv` when instantiating a new `AppService`.

Other changes:
- `optparse` (now deprecated) has been replaced by the new standard `argparse`

**How has the changes been tested?**
A new test has been added and the changes are non-breaking

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
